### PR TITLE
Backport let!()

### DIFF
--- a/lib/spec/example/example_group_methods.rb
+++ b/lib/spec/example/example_group_methods.rb
@@ -172,6 +172,11 @@ module Spec
         end
       end
 
+      def let!(name, &block)
+        let(name, &block)
+        before { __send__(name) }
+      end
+
     private
 
       def subclass(*args, &example_group_block)

--- a/spec/spec/example/example_group_methods_spec.rb
+++ b/spec/spec/example/example_group_methods_spec.rb
@@ -753,6 +753,25 @@ module Spec
             counter.count.should == 2
           end
         end
+
+        describe "#let!" do
+          let!(:creator) do
+            class Creator
+              @count = 0
+              def self.count
+                @count += 1
+              end
+            end
+          end
+
+          it "evaluates the value non-lazily" do
+            lambda { Creator.count }.should_not raise_error
+          end
+
+          it "does not interfere between tests" do
+            Creator.count.should == 1
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
We've got a Rails 3 / RSpec 2 project and 2 "legacy" Rails 2.3 / RSpec 1 projects that aren't going get upgraded overnight. Would love to have RSpec 2' let!() available in these projects.

I found conflicting reports on how to submit patches so I hope GitHub's newer pull requests are okay.
