### PR TITLE
Ignore rubinius byte code files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ tmp
 *.sw?
 spec/spec_files.txt
 tags
+
+# rubinius byte code files
+*.rbc


### PR DESCRIPTION
When you run anything with rubinius, it generates a bunch of *.rbc files.  These should be ignored.
