### PR TITLE
rake spec gives error "no such file or directory 'spec/spec.opts'"

### DIFF
--- a/spec/spec/runner/option_parser_spec.rb
+++ b/spec/spec/runner/option_parser_spec.rb
@@ -527,23 +527,29 @@ describe "OptionParser" do
     include FakeFS::SpecHelpers
 
     it "uses spec/spec.opts if present" do
-      File.open('spec/spec.opts', 'w') { |f| f.write "--colour" }
-      options = parse(['ignore.rb'])
-      options.colour.should be(true)
+      system("cd spec") do
+        File.open('spec.opts', 'w') { |f| f.write "--colour" }
+        options = parse(['ignore.rb'])
+        options.colour.should be(true)
+      end
     end
   
     it "does not try to load spec/spec.opts if not present" do
-      FileUtils.rm 'spec/spec.opts'
-      options = parse(['ignore.rb'])
-      options.colour.should be(false)
+      system("cd spec") do
+        FileUtils.rm 'spec.opts'
+        options = parse(['ignore.rb'])
+        options.colour.should be(false)
+      end
     end
   
     it "uses specified opts if supplied" do
-      options = nil
-      File.open("spec/spec.opts",'w') { |f| f.write "" }
-      File.open("spec/alternate.opts",'w') { |f| f.write "--colour" }
-      options = parse(['-O','spec/alternate.opts'])
-      options.colour.should be(true)
+      system("cd spec") do
+        options = nil
+        File.open("spec.opts",'w') { |f| f.write "" }
+        File.open("alternate.opts",'w') { |f| f.write "--colour" }
+        options = parse(['-O','spec/alternate.opts'])
+        options.colour.should be(true)
+      end
     end
   end
   


### PR DESCRIPTION
I have fixed the failures in the test cases of spec/spec/runner/option_parser_spec_failure.rb. As it was breaking at three places i.e. line #530, line #538, line #544 . The error messages are mentioned below 

1)
Errno::ENOENT in 'OptionParser implicitly loading spec/spec.opts uses spec/spec.opts if present'
No such file or directory - No such file or directory - spec/spec.opts
/.rvm/gems/ruby-1.8.7-p357/gems/fakefs-0.4.0/lib/fakefs/file.rb:418:in `create_missing_file'
/.rvm/gems/ruby-1.8.7-p357/gems/fakefs-0.4.0/lib/fakefs/file.rb:273:in`initialize'
./spec/spec/runner/option_parser_spec.rb:531:in `open'
./spec/spec/runner/option_parser_spec.rb:531:

2)
Errno::ENOENT in 'OptionParser implicitly loading spec/spec.opts does not try to load spec/spec.opts if not present'
No such file or directory - spec/spec.opts
/.rvm/gems/ruby-1.8.7-p357/gems/fakefs-0.4.0/lib/fakefs/fileutils.rb:33:in `rm'
/.rvm/gems/ruby-1.8.7-p357/gems/fakefs-0.4.0/lib/fakefs/fileutils.rb:32:in`each'
/.rvm/gems/ruby-1.8.7-p357/gems/fakefs-0.4.0/lib/fakefs/fileutils.rb:32:in `rm'
./spec/spec/runner/option_parser_spec.rb:537:

3)
Errno::ENOENT in 'OptionParser implicitly loading spec/spec.opts uses specified opts if supplied'
No such file or directory - No such file or directory - spec/spec.opts
/.rvm/gems/ruby-1.8.7-p357/gems/fakefs-0.4.0/lib/fakefs/file.rb:418:in `create_missing_file'
/.rvm/gems/ruby-1.8.7-p357/gems/fakefs-0.4.0/lib/fakefs/file.rb:273:in`initialize'
./spec/spec/runner/option_parser_spec.rb:544:in `open'
./spec/spec/runner/option_parser_spec.rb:544:
